### PR TITLE
Generating incorrect URL for Magic Forms

### DIFF
--- a/admin/mf_admin.php
+++ b/admin/mf_admin.php
@@ -7,7 +7,7 @@ class mf_admin {
   public $name = 'mf_admin';
 
   function _get_url(  $section = 'mf_dashboard', $action = 'main', $vars = array( ) ){
-    $url = home_url();
+    $url = site_url();
 
     //the admin area of Magic Fields always should pass through the dispatcher:
     $url .= '/wp-admin/admin.php?page=mf_dispatcher';


### PR DESCRIPTION
See Issue #39 which I have replaced with this pull request. I believe this is the correct way to generate the URL for the Magic Forms admin page.
