### PR TITLE
Fix not being able to insert image into editor because of JavaScript glitch

### DIFF
--- a/js/mf_admin.js
+++ b/js/mf_admin.js
@@ -227,13 +227,13 @@ jQuery(document).ready(function($){
   jQuery('.del-link').each(function(){
     id = jQuery(this).next().attr('id');
     check = parent.window.mf_field_id;
-    if(check == ""){}else{
+    if (check){
       set = parent.window.mf_js.mf_image_media_set;
       $(this).before('<a href="#"  class="mf_media_upload button" onclick="mf_set_image_field(\''+id+'\'); return false;">'+set+'</a>');
       $(this).parent().find("input:submit").remove();        
     }
   });
-  
+
   $('.update_field_media_upload').live('click', function(){
     window.mf_field_id = jQuery(this).attr('id');
   });


### PR DESCRIPTION
I guess this is a new glitch in 3.3 but I don't know why that would be. Refer to the patch to see what I changed, it was incorrectly detecting that the user was trying to insert an Image Media field. What the user was really trying to do was insert a Media library item into the actual post editor area.

This appears to completely fix the problem.
