### PR TITLE
Update dashboard to better support Wordpress in a subdirectory

### DIFF
--- a/admin/mf_dashboard.php
+++ b/admin/mf_dashboard.php
@@ -20,8 +20,8 @@ class mf_dashboard extends mf_admin {
     $custom_taxonomies = $this->get_custom_taxonomies();
     
     print '<div class="wrap">';
-    // print screen icon
-    print get_screen_icon('magic-fields');
+    // print screen icon 	
+    print get_screen_icon('magic-fields');   
     print '<h2>'.__( 'Magic Fields',$mf_domain).'</h2>';
     print '<h3>'.__( 'Post Types', $mf_domain ).'<a href="admin.php?page=mf_dispatcher&mf_section=mf_posttype&mf_action=add_post_type" class="add-new-h2 button">'.__( 'Add new Post Type', $mf_domain ).'</a></h3>';
 
@@ -84,7 +84,7 @@ class mf_dashboard extends mf_admin {
     ?>
       <div class="message-box info">
       <p>
-        ooh, you do  haven't created any Custom Taxonomy,  try creating one <a href="<?php print bloginfo('url');?>/wp-admin/admin.php?page=mf_dispatcher&mf_section=mf_custom_taxonomy&mf_action=add_custom_taxonomy">here</a>
+        ooh, you do  haven't created any Custom Taxonomy,  try creating one <a href="admin.php?page=mf_dispatcher&mf_section=mf_custom_taxonomy&mf_action=add_custom_taxonomy">here</a>
       </p>
       </div>
 


### PR DESCRIPTION
This patch is intended to fix a url that is incorrect when wordpress is installed in a subdirectory (instead of at the root of the url), and to make that url consistent with the other urls.
