### PR TITLE
Changed MF_BASENAME

### DIFF
--- a/mf_constants.php
+++ b/mf_constants.php
@@ -3,7 +3,7 @@ global $wpdb,$blog_id;
 
 //useful for get quickly the path for  images/javascript files and css files
 //return something like: http://wordpress.local/wp-content/plugins/Magic-Fields/
-define('MF_BASENAME',plugins_url().'/'.str_replace(basename(__FILE__),"",plugin_basename(__FILE__)));
+define('MF_BASENAME',plugins_url().'/'.basename(dirname(__FILE__)).'/');
 define('MF_URL',MF_BASENAME);
 
 //return something like: /Users/user/sites/wordpres/wp-content/plugins/Magic-Fields


### PR DESCRIPTION
When using Magic Fields in a shared environment, as a Git submodule or something thats symlinked, the old way of getting the MF_BASENAME returned the "actual" path to a file. This way it works on more installations.
