### PR TITLE
TinyMCE multiline and featured image problems

### DIFF
--- a/admin/mf_post.php
+++ b/admin/mf_post.php
@@ -15,6 +15,10 @@ class mf_post extends mf_admin {
 
     //
     add_action( 'admin_footer', array( &$this,'mf_check_wp_gallery_version') );
+    
+    // Add tiny_mce script if required
+	 add_action('admin_footer', array( &$this,'check_exist_visual_editor'));
+
   }
 
   function mf_check_wp_gallery_version() {

--- a/main.php
+++ b/main.php
@@ -237,7 +237,7 @@ load_plugin_textdomain('magic_fields', '/'.PLUGINDIR.'/'.dirname(plugin_basename
       if( strstr( $_SERVER['REQUEST_URI'], 'post-new.php' ) !== FALSE  || strstr( $_SERVER['REQUEST_URI'],  'wp-admin/post.php') !== FALSE ) {
         /* Load JS and CSS for post page */
         $css_js = new mf_post();
-        $css_js->check_exist_visual_editor();
+      //  $css_js->check_exist_visual_editor();
         $css_js->load_js_css_base();
         $css_js->load_js_css_fields();
         $css_js->general_option_multiline();


### PR DESCRIPTION
I've been having problems with posts which use Magic Fields multiline. Specifically, the TinyMCE editor did not load for multiline fields and setting the featured image failed. After much digging through the source code, I tracked the problem down to Commit: 5e88e44c8a9ecedb341e01c930f01bda02bae257 [5e88e44] which outputs a TinyMCE editor right at the top of the HTML before even the DocType.
