### PR TITLE
change split for explode on mf_sort_field

### DIFF
--- a/admin/mf_ajax_call.php
+++ b/admin/mf_ajax_call.php
@@ -28,7 +28,7 @@ class mf_ajax_call{
   public function mf_sort_field($data){
     if ( !empty( $data['order'] ) && !empty( $data['group_id'] ) ) {
       $order = $data['order'];
-      $order = split(',',$order);
+      $order = explode(',',$order);
       array_walk( $order, create_function( '&$v,$k', '$v =  str_replace("order_","",$v);' ));
 
       if( $thing =  mf_custom_fields::save_order_field( $data['group_id'], $order ) ) {


### PR DESCRIPTION
On PHP7 split function has removed (http://php.net/split). 

When user try change order of fields this is not possible because a Fatal error occours.